### PR TITLE
Secure sensitive API endpoints 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,13 @@
 # Copy this file to .env and fill in your values.
 # ─────────────────────────────────────────────────
 
+# ── API Security ────────────────────────────────
+# Shared secret required by sensitive API endpoints.
+API_KEY=
+
+# Keep docs disabled in production unless explicitly needed.
+# EXPOSE_API_DOCS=false
+
 # ── LLM Provider ────────────────────────────────
 LLM_PROVIDER=google
 GEMINI_API_KEY=         

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,7 @@ Start the local dev service:
 uv sync --dev
 cp .env.example .env
 # Edit .env and set at least:
+# API_KEY=...
 # LLM_PROVIDER=google
 # GEMINI_API_KEY=...
 # QDRANT_URL=http://localhost:6333

--- a/README.md
+++ b/README.md
@@ -59,16 +59,18 @@ docker compose build
 docker compose up -d
 ```
 
-Fill in `.env` (see the [Configuration](#configuration) section below). The API is available at `http://localhost:8000`. Interactive docs at `http://localhost:8000/api/v1/docs`.
+Fill in `.env` (see the [Configuration](#configuration) section below). The API is available at `http://localhost:8000`. Interactive docs are disabled by default and can be enabled with `EXPOSE_API_DOCS=true`.
 
 ### Ingest and query
 
 ```bash
 # Sync Discord message history to Qdrant
-curl -X POST http://localhost:8000/api/v1/ingest/discord
+curl -X POST http://localhost:8000/api/v1/ingest/discord \
+  -H "X-API-Key: ${API_KEY}"
 
 # Ask a question
 curl -X POST http://localhost:8000/api/v1/ask \
+  -H "X-API-Key: ${API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"question":"When is the next event?"}'
 ```
@@ -83,6 +85,7 @@ All settings are environment variables loaded from `.env` via `pydantic-settings
 
 | Variable              | Description                                                      |
 | --------------------- | ---------------------------------------------------------------- |
+| `API_KEY`             | Shared secret required for protected API routes                  |
 | `GEMINI_API_KEY`      | Google Gemini API key (used for LLM + embeddings)                |
 | `QDRANT_URL`          | Qdrant Cloud instance URL (e.g. `https://xxxxx.cloud.qdrant.io`) |
 | `QDRANT_API_KEY`      | Qdrant Cloud API key                                             |
@@ -93,6 +96,9 @@ All settings are environment variables loaded from `.env` via `pydantic-settings
 
 | Variable                   | Default                               | Description                                                        |
 | -------------------------- | ------------------------------------- | ------------------------------------------------------------------ |
+| `API_AUTH_ENABLED`         | `true`                                | Protects sensitive routes with the shared API key                  |
+| `API_KEY_HEADER`           | `X-API-Key`                           | Header used to send the shared API key                             |
+| `EXPOSE_API_DOCS`          | `false`                               | Enables `/docs`, `/redoc`, and the OpenAPI schema when set to true |
 | `ORG_NAME`                 | `MicroClub`                           | Organization name embedded in the AI system prompt                 |
 | `ORG_DESCRIPTION`          | `A generic organization using mAIcro` | Organization description                                           |
 | `GOOGLE_MODEL_NAME`        | `gemini-2.5-flash`                    | Gemini model used for answering                                    |
@@ -228,12 +234,14 @@ curl http://localhost:8000/api/v1/health
 
 # Ask a question
 curl -X POST http://localhost:8000/api/v1/ask \
+  -H "X-API-Key: ${API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"question":"What are the rules for joining a workshop?"}'
 # {"question":"What are the rules for joining a workshop?","answer":"..."}
 
 # Trigger ingestion
-curl -X POST http://localhost:8000/api/v1/ingest/discord
+curl -X POST http://localhost:8000/api/v1/ingest/discord \
+  -H "X-API-Key: ${API_KEY}"
 # {"status":"ok","documents_ingested":42,"details":{"channels":{"123456789":42},"errors":{}}}
 ```
 
@@ -251,7 +259,7 @@ Includes mAIcro and a local Qdrant instance for testing without cloud credential
 
 ### Production
 
-The published GHCR image is public; anyone can pull and run it with no authentication needed.
+The published GHCR image is public, but the API itself now expects an `API_KEY` for sensitive routes by default.
 
 ```bash
 docker compose up -d

--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -4,10 +4,11 @@ mAIcro REST API routes.
 
 import asyncio
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 
 from api.schemas import AskRequest, AskResponse, IngestResponse
 from core.config import settings
+from core.security import require_api_key
 from services.qa_service import ask_question
 
 router = APIRouter()
@@ -24,7 +25,7 @@ async def health():
     }
 
 
-@router.post("/ask", response_model=AskResponse)
+@router.post("/ask", response_model=AskResponse, dependencies=[Depends(require_api_key)])
 async def ask(req: AskRequest):
     """Answer a question using the RAG chain."""
     if not req.question.strip():
@@ -36,7 +37,11 @@ async def ask(req: AskRequest):
     return AskResponse(question=req.question, answer=answer)
 
 
-@router.post("/ingest/discord", response_model=IngestResponse)
+@router.post(
+    "/ingest/discord",
+    response_model=IngestResponse,
+    dependencies=[Depends(require_api_key)],
+)
 async def ingest_discord():
     """Fetch messages from Discord channels and ingest them."""
     from core.ingestion import ingest_from_discord

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -6,6 +6,10 @@ class Settings(BaseSettings):
     PROJECT_NAME: str = "mAIcro"
     VERSION: str = "0.1.0"
     API_V1_STR: str = "/api/v1"
+    API_AUTH_ENABLED: bool = True
+    API_KEY: Optional[str] = None
+    API_KEY_HEADER: str = "X-API-Key"
+    EXPOSE_API_DOCS: bool = False
 
     ORG_NAME: str = "MicroClub"
     ORG_DESCRIPTION: Optional[str] = "A generic organization using mAIcro"
@@ -52,4 +56,3 @@ class Settings(BaseSettings):
 
 
 settings = Settings()
-

--- a/src/core/security.py
+++ b/src/core/security.py
@@ -1,0 +1,50 @@
+"""API authentication helpers for sensitive routes."""
+
+from __future__ import annotations
+
+import hmac
+
+from fastapi import HTTPException, Request, Security, status
+from fastapi.security import APIKeyHeader
+
+from core.config import settings
+
+
+api_key_header = APIKeyHeader(name=settings.API_KEY_HEADER, auto_error=False)
+
+
+def _get_provided_api_key(request: Request, header_value: str | None) -> str | None:
+    if header_value:
+        return header_value.strip()
+
+    authorization = request.headers.get("Authorization", "").strip()
+    if authorization.lower().startswith("bearer "):
+        token = authorization[7:].strip()
+        return token or None
+
+    return None
+
+
+def require_api_key(
+    request: Request,
+    header_value: str | None = Security(api_key_header),
+) -> None:
+    """Protect sensitive endpoints with a shared API key."""
+    if not settings.API_AUTH_ENABLED:
+        return
+
+    if not settings.API_KEY:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=(
+                "API authentication is enabled but API_KEY is not configured on the server."
+            ),
+        )
+
+    provided_key = _get_provided_api_key(request, header_value)
+    if not provided_key or not hmac.compare_digest(provided_key, settings.API_KEY):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or missing API key.",
+            headers={"WWW-Authenticate": "ApiKey"},
+        )

--- a/src/main.py
+++ b/src/main.py
@@ -51,8 +51,11 @@ app = FastAPI(
         f"AI knowledge service for {settings.ORG_NAME}. "
         "Ingest data from Discord or JSON files, then ask questions."
     ),
-    docs_url=f"{settings.API_V1_STR}/docs",
-    redoc_url=f"{settings.API_V1_STR}/redoc",
+    docs_url=f"{settings.API_V1_STR}/docs" if settings.EXPOSE_API_DOCS else None,
+    redoc_url=f"{settings.API_V1_STR}/redoc" if settings.EXPOSE_API_DOCS else None,
+    openapi_url=(
+        f"{settings.API_V1_STR}/openapi.json" if settings.EXPOSE_API_DOCS else None
+    ),
 )
 
 

--- a/tests/api/test_routes.py
+++ b/tests/api/test_routes.py
@@ -3,6 +3,7 @@ import asyncio
 import httpx
 
 import api.routes as routes
+from core.config import settings
 from services.qa_service import AskError
 from main import app
 
@@ -26,16 +27,33 @@ def test_health_endpoint_returns_ok():
 
 
 def test_ask_rejects_empty_question():
-    res = request("POST", "/api/v1/ask", json={"question": "   "})
+    res = request(
+        "POST",
+        "/api/v1/ask",
+        headers={settings.API_KEY_HEADER: settings.API_KEY},
+        json={"question": "   "},
+    )
 
     assert res.status_code == 400
     assert "cannot be empty" in res.json()["detail"].lower()
 
 
+def test_ask_requires_api_key():
+    res = request("POST", "/api/v1/ask", json={"question": "hello"})
+
+    assert res.status_code == 401
+    assert "api key" in res.json()["detail"].lower()
+
+
 def test_ask_success(monkeypatch):
     monkeypatch.setattr(routes, "ask_question", lambda q: "answer: " + q)
 
-    res = request("POST", "/api/v1/ask", json={"question": "hello"})
+    res = request(
+        "POST",
+        "/api/v1/ask",
+        headers={settings.API_KEY_HEADER: settings.API_KEY},
+        json={"question": "hello"},
+    )
 
     assert res.status_code == 200
     assert res.json() == {"question": "hello", "answer": "answer: hello"}
@@ -47,7 +65,12 @@ def test_ask_error_is_mapped_to_502(monkeypatch):
 
     monkeypatch.setattr(routes, "ask_question", _raise)
 
-    res = request("POST", "/api/v1/ask", json={"question": "hello"})
+    res = request(
+        "POST",
+        "/api/v1/ask",
+        headers={settings.API_KEY_HEADER: settings.API_KEY},
+        json={"question": "hello"},
+    )
 
     assert res.status_code == 502
     assert "upstream failed" in res.json()["detail"]
@@ -57,10 +80,21 @@ def test_ingest_discord_requires_token(monkeypatch):
     monkeypatch.setattr(routes.settings, "DISCORD_BOT_TOKEN", None)
     monkeypatch.setattr(routes.settings, "DISCORD_CHANNEL_IDS", "123")
 
-    res = request("POST", "/api/v1/ingest/discord")
+    res = request(
+        "POST",
+        "/api/v1/ingest/discord",
+        headers={settings.API_KEY_HEADER: settings.API_KEY},
+    )
 
     assert res.status_code == 400
     assert "DISCORD_BOT_TOKEN" in res.json()["detail"]
+
+
+def test_ingest_discord_requires_api_key():
+    res = request("POST", "/api/v1/ingest/discord")
+
+    assert res.status_code == 401
+    assert "api key" in res.json()["detail"].lower()
 
 
 def test_ingest_discord_partial_response(monkeypatch):
@@ -78,7 +112,11 @@ def test_ingest_discord_partial_response(monkeypatch):
 
     monkeypatch.setattr(ingestion, "ingest_from_discord", _fake_ingest)
 
-    res = request("POST", "/api/v1/ingest/discord")
+    res = request(
+        "POST",
+        "/api/v1/ingest/discord",
+        headers={settings.API_KEY_HEADER: settings.API_KEY},
+    )
 
     assert res.status_code == 200
     body = res.json()
@@ -86,3 +124,9 @@ def test_ingest_discord_partial_response(monkeypatch):
     assert body["documents_ingested"] == 5
     assert body["details"]["channels"] == {"123": 5}
     assert body["details"]["errors"] == {"456": "missing access"}
+
+
+def test_docs_are_disabled_by_default():
+    res = request("GET", "/api/v1/docs")
+
+    assert res.status_code == 404

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,14 @@
 import pytest
 from core.config import settings
 
+
 @pytest.fixture(autouse=True)
 def mock_env_vars(monkeypatch):
     """Provide dummy environment variables for all tests to bypass strict Cloud-only checks."""
+    monkeypatch.setattr(settings, "API_AUTH_ENABLED", True)
+    monkeypatch.setattr(settings, "API_KEY", "test-api-key")
+    monkeypatch.setattr(settings, "API_KEY_HEADER", "X-API-Key")
+    monkeypatch.setattr(settings, "EXPOSE_API_DOCS", False)
     monkeypatch.setattr(settings, "QDRANT_URL", "https://dummy.qdrant.io:6333")
     monkeypatch.setattr(settings, "QDRANT_API_KEY", "dummy-api-key")
     monkeypatch.setattr(settings, "GEMINI_API_KEY", "dummy-gemini-key")


### PR DESCRIPTION
## Summary

This PR secures the sensitive API surface exposed by mAIcro.

### Changes
- add shared API key protection for `/api/v1/ask` and `/api/v1/ingest/discord`
- keep `/api/v1/health` public
- disable Swagger, ReDoc, and OpenAPI schema by default
- add security-related settings:
  - `API_AUTH_ENABLED`
  - `API_KEY`
  - `API_KEY_HEADER`
  - `EXPOSE_API_DOCS`
- document the new behavior in `.env.example`, `README.md`, and `CONTRIBUTING.md`
- extend API tests to cover:
  - `401` when API key is missing
  - success when API key is provided
  - docs disabled by default

## Why

Previously, sensitive endpoints were accessible without authentication at the application layer. In deployments where the container is network-accessible, this allowed:
- querying internal RAG knowledge without authorization
- triggering expensive Discord ingestion jobs
- easy discovery of the API surface through public docs

This PR adds a minimal but production-appropriate application-layer control to reduce that risk.
