### PR TITLE
Fix/startup audit window

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,13 @@
 # Copy this file to .env and fill in your values.
 # ─────────────────────────────────────────────────
 
+# ── API Security ────────────────────────────────
+# Shared secret required by sensitive API endpoints.
+API_KEY=
+
+# Keep docs disabled in production unless explicitly needed.
+# EXPOSE_API_DOCS=false
+
 # ── LLM Provider ────────────────────────────────
 LLM_PROVIDER=google
 GEMINI_API_KEY=         

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,7 @@ Start the local dev service:
 uv sync --dev
 cp .env.example .env
 # Edit .env and set at least:
+# API_KEY=...
 # LLM_PROVIDER=google
 # GEMINI_API_KEY=...
 # QDRANT_URL=http://localhost:6333

--- a/README.md
+++ b/README.md
@@ -59,16 +59,18 @@ docker compose build
 docker compose up -d
 ```
 
-Fill in `.env` (see the [Configuration](#configuration) section below). The API is available at `http://localhost:8000`. Interactive docs at `http://localhost:8000/api/v1/docs`.
+Fill in `.env` (see the [Configuration](#configuration) section below). The API is available at `http://localhost:8000`. Interactive docs are disabled by default and can be enabled with `EXPOSE_API_DOCS=true`.
 
 ### Ingest and query
 
 ```bash
 # Sync Discord message history to Qdrant
-curl -X POST http://localhost:8000/api/v1/ingest/discord
+curl -X POST http://localhost:8000/api/v1/ingest/discord \
+  -H "X-API-Key: ${API_KEY}"
 
 # Ask a question
 curl -X POST http://localhost:8000/api/v1/ask \
+  -H "X-API-Key: ${API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"question":"When is the next event?"}'
 ```
@@ -83,6 +85,7 @@ All settings are environment variables loaded from `.env` via `pydantic-settings
 
 | Variable              | Description                                                      |
 | --------------------- | ---------------------------------------------------------------- |
+| `API_KEY`             | Shared secret required for protected API routes                  |
 | `GEMINI_API_KEY`      | Google Gemini API key (used for LLM + embeddings)                |
 | `QDRANT_URL`          | Qdrant Cloud instance URL (e.g. `https://xxxxx.cloud.qdrant.io`) |
 | `QDRANT_API_KEY`      | Qdrant Cloud API key                                             |
@@ -93,6 +96,9 @@ All settings are environment variables loaded from `.env` via `pydantic-settings
 
 | Variable                   | Default                               | Description                                                        |
 | -------------------------- | ------------------------------------- | ------------------------------------------------------------------ |
+| `API_AUTH_ENABLED`         | `true`                                | Protects sensitive routes with the shared API key                  |
+| `API_KEY_HEADER`           | `X-API-Key`                           | Header used to send the shared API key                             |
+| `EXPOSE_API_DOCS`          | `false`                               | Enables `/docs`, `/redoc`, and the OpenAPI schema when set to true |
 | `ORG_NAME`                 | `MicroClub`                           | Organization name embedded in the AI system prompt                 |
 | `ORG_DESCRIPTION`          | `A generic organization using mAIcro` | Organization description                                           |
 | `GOOGLE_MODEL_NAME`        | `gemini-2.5-flash`                    | Gemini model used for answering                                    |
@@ -228,12 +234,14 @@ curl http://localhost:8000/api/v1/health
 
 # Ask a question
 curl -X POST http://localhost:8000/api/v1/ask \
+  -H "X-API-Key: ${API_KEY}" \
   -H "Content-Type: application/json" \
   -d '{"question":"What are the rules for joining a workshop?"}'
 # {"question":"What are the rules for joining a workshop?","answer":"..."}
 
 # Trigger ingestion
-curl -X POST http://localhost:8000/api/v1/ingest/discord
+curl -X POST http://localhost:8000/api/v1/ingest/discord \
+  -H "X-API-Key: ${API_KEY}"
 # {"status":"ok","documents_ingested":42,"details":{"channels":{"123456789":42},"errors":{}}}
 ```
 
@@ -251,7 +259,7 @@ Includes mAIcro and a local Qdrant instance for testing without cloud credential
 
 ### Production
 
-The published GHCR image is public; anyone can pull and run it with no authentication needed.
+The published GHCR image is public, but the API itself now expects an `API_KEY` for sensitive routes by default.
 
 ```bash
 docker compose up -d

--- a/src/api/routes.py
+++ b/src/api/routes.py
@@ -4,10 +4,11 @@ mAIcro REST API routes.
 
 import asyncio
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, Depends, HTTPException
 
 from api.schemas import AskRequest, AskResponse, IngestResponse
 from core.config import settings
+from core.security import require_api_key
 from services.qa_service import ask_question
 
 router = APIRouter()
@@ -24,7 +25,7 @@ async def health():
     }
 
 
-@router.post("/ask", response_model=AskResponse)
+@router.post("/ask", response_model=AskResponse, dependencies=[Depends(require_api_key)])
 async def ask(req: AskRequest):
     """Answer a question using the RAG chain."""
     if not req.question.strip():
@@ -36,7 +37,11 @@ async def ask(req: AskRequest):
     return AskResponse(question=req.question, answer=answer)
 
 
-@router.post("/ingest/discord", response_model=IngestResponse)
+@router.post(
+    "/ingest/discord",
+    response_model=IngestResponse,
+    dependencies=[Depends(require_api_key)],
+)
 async def ingest_discord():
     """Fetch messages from Discord channels and ingest them."""
     from core.ingestion import ingest_from_discord

--- a/src/core/audit.py
+++ b/src/core/audit.py
@@ -2,13 +2,20 @@
 Audit module — handles startup reconciliation of offline edits and deletes.
 """
 
+import logging
 
 from core.config import settings
 from core.discord_fetcher import fetch_channel_messages, fetch_message_by_id
 from core.state import get_last_ingested_message_id, ensure_channel_in_state, update_last_ingested_message_id
-import logging
 
 logger = logging.getLogger(__name__)
+
+
+def _message_id_to_int(message_id: str) -> int | None:
+    try:
+        return int(str(message_id))
+    except (TypeError, ValueError):
+        return None
 
 
 async def run_startup_audit(
@@ -127,15 +134,17 @@ async def run_startup_audit(
                 limit=window,
                 before=last_message_id,
             )
-            
+
             discord_index: dict[str, str] = {}
+            recent_lookup: dict[str, dict] = {}
             cursor_id_str = str(cursor_msg["id"])
             discord_index[cursor_id_str] = cursor_content
-            
+
             for msg in recent:
                 docs = _docs_from_discord_messages([msg], channel_id)
                 msg_id_str = str(msg["id"])
                 discord_index[msg_id_str] = docs[0].page_content if docs else ""
+                recent_lookup[msg_id_str] = msg
             if not discord_index:
                 logger.info(
                     "[audit] Channel %s: no messages before cursor to audit",
@@ -143,6 +152,14 @@ async def run_startup_audit(
                 )
                 summary[channel_id] = {"deleted": 0, "updated": 0, "skipped": "no_messages_before_cursor"}
                 continue
+
+            cursor_id_int = _message_id_to_int(cursor_id_str)
+            audited_ids = [
+                parsed_id
+                for parsed_id in (_message_id_to_int(msg_id) for msg_id in discord_index)
+                if parsed_id is not None
+            ]
+            audit_lower_bound = min(audited_ids) if audited_ids else cursor_id_int
             try:
                 _bootstrap_collection()
             except Exception as e:
@@ -191,6 +208,22 @@ async def run_startup_audit(
                     if not msg_id:
                         continue
                     msg_id_str = str(msg_id)
+                    msg_id_int = _message_id_to_int(msg_id_str)
+                    if msg_id_int is None:
+                        logger.debug("[audit] Skipping non-numeric message_id=%s", msg_id_str)
+                        continue
+                    if (
+                        audit_lower_bound is not None
+                        and cursor_id_int is not None
+                        and not audit_lower_bound <= msg_id_int <= cursor_id_int
+                    ):
+                        logger.debug(
+                            "[audit] Skipping message_id=%s outside audited window [%s, %s]",
+                            msg_id_str,
+                            audit_lower_bound,
+                            cursor_id_int,
+                        )
+                        continue
                     logger.debug(
                         "[audit] Checking msg_id=%s (type=%s) - in discord_index=%s",
                         msg_id_str, type(msg_id), msg_id_str in discord_index,
@@ -218,9 +251,7 @@ async def run_startup_audit(
                         if msg_id_str == cursor_id_str:
                             msg_dict = cursor_msg
                         else:
-                            msg_dict = next(
-                                (m for m in recent if str(m["id"]) == msg_id_str), None
-                            )
+                            msg_dict = recent_lookup.get(msg_id_str)
                         if msg_dict:
                             update_message_in_store(msg_dict, channel_id)
                             updated += 1

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -6,6 +6,10 @@ class Settings(BaseSettings):
     PROJECT_NAME: str = "mAIcro"
     VERSION: str = "0.1.0"
     API_V1_STR: str = "/api/v1"
+    API_AUTH_ENABLED: bool = True
+    API_KEY: Optional[str] = None
+    API_KEY_HEADER: str = "X-API-Key"
+    EXPOSE_API_DOCS: bool = False
 
     ORG_NAME: str = "MicroClub"
     ORG_DESCRIPTION: Optional[str] = "A generic organization using mAIcro"
@@ -52,4 +56,3 @@ class Settings(BaseSettings):
 
 
 settings = Settings()
-

--- a/src/core/security.py
+++ b/src/core/security.py
@@ -1,0 +1,50 @@
+"""API authentication helpers for sensitive routes."""
+
+from __future__ import annotations
+
+import hmac
+
+from fastapi import HTTPException, Request, Security, status
+from fastapi.security import APIKeyHeader
+
+from core.config import settings
+
+
+api_key_header = APIKeyHeader(name=settings.API_KEY_HEADER, auto_error=False)
+
+
+def _get_provided_api_key(request: Request, header_value: str | None) -> str | None:
+    if header_value:
+        return header_value.strip()
+
+    authorization = request.headers.get("Authorization", "").strip()
+    if authorization.lower().startswith("bearer "):
+        token = authorization[7:].strip()
+        return token or None
+
+    return None
+
+
+def require_api_key(
+    request: Request,
+    header_value: str | None = Security(api_key_header),
+) -> None:
+    """Protect sensitive endpoints with a shared API key."""
+    if not settings.API_AUTH_ENABLED:
+        return
+
+    if not settings.API_KEY:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail=(
+                "API authentication is enabled but API_KEY is not configured on the server."
+            ),
+        )
+
+    provided_key = _get_provided_api_key(request, header_value)
+    if not provided_key or not hmac.compare_digest(provided_key, settings.API_KEY):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Invalid or missing API key.",
+            headers={"WWW-Authenticate": "ApiKey"},
+        )

--- a/src/main.py
+++ b/src/main.py
@@ -51,8 +51,11 @@ app = FastAPI(
         f"AI knowledge service for {settings.ORG_NAME}. "
         "Ingest data from Discord or JSON files, then ask questions."
     ),
-    docs_url=f"{settings.API_V1_STR}/docs",
-    redoc_url=f"{settings.API_V1_STR}/redoc",
+    docs_url=f"{settings.API_V1_STR}/docs" if settings.EXPOSE_API_DOCS else None,
+    redoc_url=f"{settings.API_V1_STR}/redoc" if settings.EXPOSE_API_DOCS else None,
+    openapi_url=(
+        f"{settings.API_V1_STR}/openapi.json" if settings.EXPOSE_API_DOCS else None
+    ),
 )
 
 

--- a/tests/api/test_routes.py
+++ b/tests/api/test_routes.py
@@ -3,6 +3,7 @@ import asyncio
 import httpx
 
 import api.routes as routes
+from core.config import settings
 from services.qa_service import AskError
 from main import app
 
@@ -26,16 +27,33 @@ def test_health_endpoint_returns_ok():
 
 
 def test_ask_rejects_empty_question():
-    res = request("POST", "/api/v1/ask", json={"question": "   "})
+    res = request(
+        "POST",
+        "/api/v1/ask",
+        headers={settings.API_KEY_HEADER: settings.API_KEY},
+        json={"question": "   "},
+    )
 
     assert res.status_code == 400
     assert "cannot be empty" in res.json()["detail"].lower()
 
 
+def test_ask_requires_api_key():
+    res = request("POST", "/api/v1/ask", json={"question": "hello"})
+
+    assert res.status_code == 401
+    assert "api key" in res.json()["detail"].lower()
+
+
 def test_ask_success(monkeypatch):
     monkeypatch.setattr(routes, "ask_question", lambda q: "answer: " + q)
 
-    res = request("POST", "/api/v1/ask", json={"question": "hello"})
+    res = request(
+        "POST",
+        "/api/v1/ask",
+        headers={settings.API_KEY_HEADER: settings.API_KEY},
+        json={"question": "hello"},
+    )
 
     assert res.status_code == 200
     assert res.json() == {"question": "hello", "answer": "answer: hello"}
@@ -47,7 +65,12 @@ def test_ask_error_is_mapped_to_502(monkeypatch):
 
     monkeypatch.setattr(routes, "ask_question", _raise)
 
-    res = request("POST", "/api/v1/ask", json={"question": "hello"})
+    res = request(
+        "POST",
+        "/api/v1/ask",
+        headers={settings.API_KEY_HEADER: settings.API_KEY},
+        json={"question": "hello"},
+    )
 
     assert res.status_code == 502
     assert "upstream failed" in res.json()["detail"]
@@ -57,10 +80,21 @@ def test_ingest_discord_requires_token(monkeypatch):
     monkeypatch.setattr(routes.settings, "DISCORD_BOT_TOKEN", None)
     monkeypatch.setattr(routes.settings, "DISCORD_CHANNEL_IDS", "123")
 
-    res = request("POST", "/api/v1/ingest/discord")
+    res = request(
+        "POST",
+        "/api/v1/ingest/discord",
+        headers={settings.API_KEY_HEADER: settings.API_KEY},
+    )
 
     assert res.status_code == 400
     assert "DISCORD_BOT_TOKEN" in res.json()["detail"]
+
+
+def test_ingest_discord_requires_api_key():
+    res = request("POST", "/api/v1/ingest/discord")
+
+    assert res.status_code == 401
+    assert "api key" in res.json()["detail"].lower()
 
 
 def test_ingest_discord_partial_response(monkeypatch):
@@ -78,7 +112,11 @@ def test_ingest_discord_partial_response(monkeypatch):
 
     monkeypatch.setattr(ingestion, "ingest_from_discord", _fake_ingest)
 
-    res = request("POST", "/api/v1/ingest/discord")
+    res = request(
+        "POST",
+        "/api/v1/ingest/discord",
+        headers={settings.API_KEY_HEADER: settings.API_KEY},
+    )
 
     assert res.status_code == 200
     body = res.json()
@@ -86,3 +124,9 @@ def test_ingest_discord_partial_response(monkeypatch):
     assert body["documents_ingested"] == 5
     assert body["details"]["channels"] == {"123": 5}
     assert body["details"]["errors"] == {"456": "missing access"}
+
+
+def test_docs_are_disabled_by_default():
+    res = request("GET", "/api/v1/docs")
+
+    assert res.status_code == 404

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,14 @@
 import pytest
 from core.config import settings
 
+
 @pytest.fixture(autouse=True)
 def mock_env_vars(monkeypatch):
     """Provide dummy environment variables for all tests to bypass strict Cloud-only checks."""
+    monkeypatch.setattr(settings, "API_AUTH_ENABLED", True)
+    monkeypatch.setattr(settings, "API_KEY", "test-api-key")
+    monkeypatch.setattr(settings, "API_KEY_HEADER", "X-API-Key")
+    monkeypatch.setattr(settings, "EXPOSE_API_DOCS", False)
     monkeypatch.setattr(settings, "QDRANT_URL", "https://dummy.qdrant.io:6333")
     monkeypatch.setattr(settings, "QDRANT_API_KEY", "dummy-api-key")
     monkeypatch.setattr(settings, "GEMINI_API_KEY", "dummy-gemini-key")

--- a/tests/unit/test_audit.py
+++ b/tests/unit/test_audit.py
@@ -1,0 +1,144 @@
+import asyncio
+from types import SimpleNamespace
+
+from core import audit
+from core import ingestion
+
+
+def _message(message_id: str, content: str) -> dict:
+    return {
+        "id": message_id,
+        "content": content,
+        "author": {"username": "alice"},
+        "timestamp": f"2026-03-10T08:0{message_id[-1]}:00+00:00",
+        "embeds": [],
+    }
+
+
+def _point(message_id: str, channel_id: str, content: str):
+    return SimpleNamespace(
+        payload={
+            "page_content": f"[alice] {content}",
+            "metadata": {
+                "channel_id": channel_id,
+                "message_id": message_id,
+                "source": "discord",
+            },
+        }
+    )
+
+
+def test_startup_audit_does_not_delete_messages_older_than_audited_window(monkeypatch):
+    channel_id = "chan-1"
+    deleted_ids: list[str] = []
+
+    cursor_msg = _message("1005", "cursor")
+    recent_messages = [
+        _message("1004", "recent-1"),
+        _message("1003", "recent-2"),
+    ]
+    qdrant_points = [
+        _point("1002", channel_id, "older-outside-window"),
+        _point("1003", channel_id, "recent-2"),
+        _point("1004", channel_id, "recent-1"),
+        _point("1005", channel_id, "cursor"),
+    ]
+
+    class FakeClient:
+        def scroll(self, **kwargs):
+            filter_obj = kwargs.get("scroll_filter")
+            conditions = getattr(filter_obj, "must", []) if filter_obj else []
+            message_ids = [
+                getattr(getattr(cond, "match", None), "value", None)
+                for cond in conditions
+                if getattr(cond, "key", None) == "metadata.message_id"
+            ]
+            if message_ids == ["1005"]:
+                return [_point("1005", channel_id, "cursor")], None
+            return qdrant_points, None
+
+        def count(self, **_kwargs):
+            return SimpleNamespace(count=len(qdrant_points))
+
+    async def fake_fetch_message_by_id(**_kwargs):
+        return cursor_msg
+
+    async def fake_fetch_channel_messages(**_kwargs):
+        return recent_messages
+
+    monkeypatch.setattr(audit, "get_last_ingested_message_id", lambda _channel_id: "1005")
+    monkeypatch.setattr(audit, "fetch_message_by_id", fake_fetch_message_by_id)
+    monkeypatch.setattr(audit, "fetch_channel_messages", fake_fetch_channel_messages)
+    monkeypatch.setattr(audit, "ensure_channel_in_state", lambda _channel_id: None)
+    monkeypatch.setattr(ingestion, "_bootstrap_collection", lambda: None)
+    monkeypatch.setattr(ingestion, "get_qdrant_client", lambda: FakeClient())
+    monkeypatch.setattr(
+        ingestion,
+        "delete_message_from_store",
+        lambda _channel_id, message_id: deleted_ids.append(message_id) or 1,
+    )
+    monkeypatch.setattr(ingestion, "update_message_in_store", lambda *_args, **_kwargs: 0)
+
+    summary = asyncio.run(audit.run_startup_audit([channel_id], window=2))
+
+    assert deleted_ids == []
+    assert summary[channel_id]["deleted"] == 0
+    assert summary[channel_id]["updated"] == 0
+
+
+def test_startup_audit_deletes_missing_message_within_audited_window(monkeypatch):
+    channel_id = "chan-1"
+    deleted_ids: list[str] = []
+
+    cursor_msg = _message("1005", "cursor")
+    recent_messages = [
+        _message("1003", "recent-2"),
+        _message("1002", "recent-3"),
+    ]
+    qdrant_points = [
+        _point("1002", channel_id, "recent-3"),
+        _point("1003", channel_id, "recent-2"),
+        _point("1004", channel_id, "deleted-offline"),
+        _point("1005", channel_id, "cursor"),
+    ]
+
+    class FakeClient:
+        def scroll(self, **kwargs):
+            filter_obj = kwargs.get("scroll_filter")
+            conditions = getattr(filter_obj, "must", []) if filter_obj else []
+            message_ids = [
+                getattr(getattr(cond, "match", None), "value", None)
+                for cond in conditions
+                if getattr(cond, "key", None) == "metadata.message_id"
+            ]
+            if message_ids == ["1005"]:
+                return [_point("1005", channel_id, "cursor")], None
+            return qdrant_points, None
+
+        def count(self, **_kwargs):
+            return SimpleNamespace(count=len(qdrant_points))
+
+    async def fake_fetch_message_by_id(**_kwargs):
+        return cursor_msg
+
+    async def fake_fetch_channel_messages(**_kwargs):
+        return recent_messages
+
+    monkeypatch.setattr(audit, "get_last_ingested_message_id", lambda _channel_id: "1005")
+    monkeypatch.setattr(audit, "fetch_message_by_id", fake_fetch_message_by_id)
+    monkeypatch.setattr(audit, "fetch_channel_messages", fake_fetch_channel_messages)
+    monkeypatch.setattr(audit, "ensure_channel_in_state", lambda _channel_id: None)
+    monkeypatch.setattr(ingestion, "_bootstrap_collection", lambda: None)
+    monkeypatch.setattr(ingestion, "get_qdrant_client", lambda: FakeClient())
+    monkeypatch.setattr(
+        ingestion,
+        "delete_message_from_store",
+        lambda _channel_id, message_id: deleted_ids.append(message_id) or 1,
+    )
+    monkeypatch.setattr(ingestion, "update_message_in_store", lambda *_args, **_kwargs: 0)
+
+    summary = asyncio.run(audit.run_startup_audit([channel_id], window=2))
+
+    assert deleted_ids == ["1004"]
+    assert summary[channel_id]["deleted"] == 1
+    assert summary[channel_id]["updated"] == 0


### PR DESCRIPTION
## Summary

This PR fixes a startup audit bug that could delete valid historical Discord messages from Qdrant when they were outside the fetched audit window.

### Changes
- limit reconciliation to the message range actually covered by the audit window
- skip Qdrant records outside the audited message-id bounds
- keep offline delete detection working for messages that are inside the audited window
- replace repeated linear lookup with a message lookup map during reconciliation
- add unit tests for:
  - preserving older messages outside the audit window
  - deleting missing messages that are inside the audit window

## Why

Previously, the startup audit fetched only a bounded set of Discord messages before the cursor, but compared that partial snapshot against all Qdrant points in the channel.

That meant older valid records could be treated as missing and deleted incorrectly.

 